### PR TITLE
org.json JPMS Module Naming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
-.idea
+**/*.idea
+src/main
+dist/
+*.iml

--- a/package.sh
+++ b/package.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 SRC_FOLDER=dist/src/main/java/org/json
+MODITECT_FOLDER=dist/src/moditect
 WORKING_DIR=`pwd`
 
 # Get the original sources from Douglas Crockfords GitHub repo
 mkdir -p $SRC_FOLDER
+mkdir -p $MODITECT_FOLDER
+# Copy the module-info to the dist folder to build
+cp src/moditect/module-info.java $MODITECT_FOLDER/module-info.java
+echo "Copied the module info file"
 git clone https://github.com/stleary/JSON-java.git $SRC_FOLDER
 
 echo ""

--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,7 @@
 						</goals>
 						<configuration>
 							<additionalparam>-Xdoclint:none</additionalparam>
+                            <failOnError>false</failOnError>
 						</configuration>
 					</execution>
 				</executions>

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,27 @@
 					</instructions>
 				</configuration>
 			</plugin>
+            <!-- Force Maven to run under 1.8, The compiler is set to 1.6, and 1.7 to build the output -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M2</version>
+                <executions>
+                    <execution>
+                        <id>enforce-java</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <version>1.8.0</version>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
@@ -187,6 +208,29 @@
 					</archive>
 				</configuration>
 			</plugin>
+            <!-- Attach the generated module-info the class file. This plugin requires JDK 1.8 -->
+            <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+                <version>1.0.0.Beta1</version>
+                <executions>
+                    <execution>
+                        <id>add-module-infos</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>add-module-info</goal>
+                        </goals>
+                        <configuration>
+                            <overwriteExistingFiles>true</overwriteExistingFiles>
+                            <module>
+                                <moduleInfoFile>
+                                    src/moditect/module-info.java
+                                </moduleInfoFile>
+                            </module>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 		</plugins>
 	</build>
 </project>

--- a/src/moditect/module-info.java
+++ b/src/moditect/module-info.java
@@ -1,0 +1,3 @@
+module org.json {
+	exports org.json;
+}


### PR DESCRIPTION
This attaches a valid module-info.class file into the final packaged jar for deployment,

This keeps compatibility for JDK 1.6, while strictly naming the module.

The outputs are (jar renamed to zip)

[json-20180813.zip](https://github.com/BGehrels/JSON-java/files/2617142/json-20180813.zip)
[json-20180813-javadoc.zip](https://github.com/BGehrels/JSON-java/files/2617143/json-20180813-javadoc.zip)
[json-20180813-sources.zip](https://github.com/BGehrels/JSON-java/files/2617144/json-20180813-sources.zip)

